### PR TITLE
use extension to require github defaults

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -12,7 +12,7 @@
 
 /* Dependencies. */
 var xtend = require('xtend');
-var defaults = require('./github');
+var defaults = require('./github.json');
 
 /* Methods. */
 var own = Object.prototype.hasOwnProperty;


### PR DESCRIPTION
This mainly came about using webpack. It didn't know how to handle the json file when requiring it, so it would fall over.

Does node require have anything to say about requiring json?