### PR TITLE
<input> appears in GitHub

### DIFF
--- a/lib/github.json
+++ b/lib/github.json
@@ -100,7 +100,8 @@
     "s",
     "strike",
     "summary",
-    "details"
+    "details",
+    "input"
   ],
   "attributes": {
     "a": [


### PR DESCRIPTION
I found remark compiler removes `<input>` of check list while transforming.  I investigated and found that `sanitize()` did it.  Then I finally found that `<input>` is lack in the `tagNames` list.  So I added it to the list.