### PR TITLE
Explicitly import `github.json`

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -11,7 +11,7 @@
 /* Dependencies. */
 var has = require('has');
 var xtend = require('xtend');
-var defaults = require('./github');
+var defaults = require('./github.json');
 
 /* Expose. */
 module.exports = wrapper;


### PR DESCRIPTION
Hey:

I"m webpacking remark and a few friends and ran into the following error in a file importing `remark-html`:

```
ERROR in ./~/hast-util-sanitize/lib/index.js                                                                                       
Module not found: Error: Cannot resolve 'file' or 'directory' ./github in /Users/cloverich/Projects/chronicles/node_modules/hast-ut
 @ ./~/hast-util-sanitize/lib/index.js 15:15-34  
```

I traced it here; **I have `json-loader` set-up in my webpack config but it would only accept this if I made the filetype explicit**. I researched a bit but could not figure out if this was canonical / intentional or not -- so please accept my apologies if this is misplaced. I considered opening an issue but figured this was the same effort. 

Very much enjoying `remark` and its related projects!